### PR TITLE
Add dev status config to lib

### DIFF
--- a/Sources/NotoSansCJKsc-VF.subset.fontra/font-data.json
+++ b/Sources/NotoSansCJKsc-VF.subset.fontra/font-data.json
@@ -1,6 +1,6 @@
 {
 "unitsPerEm": 1000,
-"lib": {
+"customData": {
 "fontra.sourceStatusFieldDefinitions": [
 {
 "label": "In progress",

--- a/Sources/NotoSerifCJKjp-VF.subset.fontra/font-data.json
+++ b/Sources/NotoSerifCJKjp-VF.subset.fontra/font-data.json
@@ -1,6 +1,6 @@
 {
 "unitsPerEm": 1000,
-"lib": {
+"customData": {
 "fontra.sourceStatusFieldDefinitions": [
 {
 "label": "In progress",


### PR DESCRIPTION
This enables the "development status" column in glyph source columns. Requires an updated Fontra Pak, too.